### PR TITLE
Update to faraday v2

### DIFF
--- a/runtime/ms_rest/lib/ms_rest.rb
+++ b/runtime/ms_rest/lib/ms_rest.rb
@@ -5,6 +5,7 @@
 require 'base64'
 require 'openssl'
 require 'faraday'
+require 'faraday/retry'
 require 'timeliness'
 require 'ms_rest/version'
 

--- a/runtime/ms_rest/lib/ms_rest/retry_policy_middleware.rb
+++ b/runtime/ms_rest/lib/ms_rest/retry_policy_middleware.rb
@@ -6,7 +6,7 @@ module MsRest
   #
   # Class which handles retry policy.
   #
-  class RetryPolicyMiddleware < Faraday::Response::Middleware
+  class RetryPolicyMiddleware < Faraday::Retry::Middleware
     #
     # Initializes a new instance of the RetryPolicyMiddleware class.
     #

--- a/runtime/ms_rest/ms_rest.gemspec
+++ b/runtime/ms_rest/ms_rest.gemspec
@@ -37,5 +37,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'timeliness', '~> 0.3.10'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_runtime_dependency 'faraday', '>= 0.9', '< 2.0.0'
+  spec.add_runtime_dependency 'faraday', '>= 2.0', '< 3.a'
+  spec.add_runtime_dependency 'faraday-retry', '~> 2.4'
 end

--- a/runtime/ms_rest_azure/ms_rest_azure.gemspec
+++ b/runtime/ms_rest_azure/ms_rest_azure.gemspec
@@ -36,7 +36,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.3'
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_runtime_dependency 'faraday', '>= 0.9', '< 2.0.0'
+  spec.add_runtime_dependency 'faraday', '>= 2.0', '< 3.a'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0.6'
+  spec.add_runtime_dependency 'faraday-retry', '~> 2.4'
   spec.add_runtime_dependency 'ms_rest', '~> 0.7.6'
 end


### PR DESCRIPTION
Update `faraday` to allow `v2` by adding `faraday-retry` to replace `Faraday::Response::Middleware`
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
